### PR TITLE
Support households in clients Dux module.

### DIFF
--- a/src/store/ducks/clients.ts
+++ b/src/store/ducks/clients.ts
@@ -74,6 +74,7 @@ export type ClientsActionTypes =
   | FetchClientsAction
   | FetchHouseholdsAction
   | RemoveClientsAction
+  | RemoveHouseholdsAction
   | AnyAction;
 
 // action Creators

--- a/src/store/ducks/clients.ts
+++ b/src/store/ducks/clients.ts
@@ -62,7 +62,11 @@ interface FetchHouseholdsAction extends AnyAction{
 }
 
 /** Create type for clients reducer actions */
-export type ClientsActionTypes = FetchClientsAction | RemoveClientsAction | AnyAction;
+export type ClientsActionTypes =
+  | FetchClientsAction
+  | FetchHouseholdsAction
+  | RemoveClientsAction
+  | AnyAction;
 
 // action Creators
 

--- a/src/store/ducks/clients.ts
+++ b/src/store/ducks/clients.ts
@@ -172,3 +172,11 @@ export function getClientsArray(state: Partial<Store>): Client[] {
 export function getClientById(state: Partial<Store>, id: string): Client | null {
   return get(getClients(state), id) || null;
 }
+
+/** returns all households in the store as values whose keys are their respective ids
+ * @param {Partial<Store>} state - the redux store
+ * @return { { [key: string] : Household} } - households object as values, reepective ids as keys
+ */
+export function getHouseholdsById(state: Partial<Store>): { [key: string]: Household } {
+  return (state as any)[reducerName].householdsById;
+}

--- a/src/store/ducks/clients.ts
+++ b/src/store/ducks/clients.ts
@@ -101,6 +101,7 @@ export const removeClientsAction = {
 /** interface for clients state in redux store */
 interface ClientState {
   clientsById: { [key: string]: Client };
+  householdsById: { [key: string]: Household };
 }
 
 /** Create an immutable clients state */

--- a/src/store/ducks/clients.ts
+++ b/src/store/ducks/clients.ts
@@ -129,6 +129,11 @@ export default function reducer(
         ...state,
         clientsById: action.clientsById,
       });
+    case HOUSEHOLDS_FETCHED:
+      return SeamlessImmutable({
+        ...state,
+        householdsById: { ...state.householdsById, ...action.householdsById },
+      });
     default:
       return state;
   }

--- a/src/store/ducks/clients.ts
+++ b/src/store/ducks/clients.ts
@@ -110,6 +110,7 @@ export type ImmutableClientsState = ClientState & SeamlessImmutable.ImmutableObj
 /** initial clients-state state */
 const initialState: ImmutableClientsState = SeamlessImmutable({
   clientsById: {},
+  householdsById: {},
 });
 
 /** the clients reducer function */

--- a/src/store/ducks/clients.ts
+++ b/src/store/ducks/clients.ts
@@ -31,7 +31,7 @@ export interface Client {
   _rev: string;
 }
 
-/** Interface for household object as same as client */
+/** Interface for household object same as client */
 export type Household = Client;
 
 // actions
@@ -143,9 +143,9 @@ export default function reducer(
 
 /** returns all clients in the store as values whose keys are their respective ids
  * @param {Partial<Store>} state - the redux store
- * @return { { [key: string] : Client} } - clients object as values, reepective ids as keys
+ * @return { { [key: string] : Client} } - clients object as values, respective ids as keys
  */
-export function getClients(state: Partial<Store>): { [key: string]: Client } {
+export function getClientsById(state: Partial<Store>): { [key: string]: Client } {
   return (state as any)[reducerName].clientsById;
 }
 
@@ -154,7 +154,7 @@ export function getClients(state: Partial<Store>): { [key: string]: Client } {
  * @return {string[]} - clients ids as an array of strings
  */
 export function getClientsIdArray(state: Partial<Store>): string[] {
-  return keys(getClients(state));
+  return keys(getClientsById(state));
 }
 
 /** gets clients as an array of clients objects
@@ -162,7 +162,7 @@ export function getClientsIdArray(state: Partial<Store>): string[] {
  * @return {Client[]} - an array of clients objs
  */
 export function getClientsArray(state: Partial<Store>): Client[] {
-  return values(getClients(state));
+  return values(getClientsById(state));
 }
 
 /** get a specific client by their id
@@ -170,12 +170,12 @@ export function getClientsArray(state: Partial<Store>): Client[] {
  * @return {Client | null} a client obj if the id is found else null
  */
 export function getClientById(state: Partial<Store>, id: string): Client | null {
-  return get(getClients(state), id) || null;
+  return get(getClientsById(state), id) || null;
 }
 
 /** returns all households in the store as values whose keys are their respective ids
  * @param {Partial<Store>} state - the redux store
- * @return { { [key: string] : Household} } - households object as values, reepective ids as keys
+ * @return { { [key: string] : Household} } - households object as values, respective ids as keys
  */
 export function getHouseholdsById(state: Partial<Store>): { [key: string]: Household } {
   return (state as any)[reducerName].householdsById;

--- a/src/store/ducks/clients.ts
+++ b/src/store/ducks/clients.ts
@@ -180,3 +180,11 @@ export function getClientById(state: Partial<Store>, id: string): Client | null 
 export function getHouseholdsById(state: Partial<Store>): { [key: string]: Household } {
   return (state as any)[reducerName].householdsById;
 }
+
+/** gets households as an array of households objects
+ * @param {Partial<Store>} state - the redux store
+ * @return {Household[]} - an array of households objs
+ */
+export function getHouseholdsArray(state: Partial<Store>): Household[] {
+  return values(getHouseholdsById(state));
+}

--- a/src/store/ducks/clients.ts
+++ b/src/store/ducks/clients.ts
@@ -105,6 +105,12 @@ export const removeClientsAction = {
   type: REMOVE_CLIENTS,
 };
 
+/** removeHouseholds action */
+export const removeHouseholdsAction: RemoveHouseholdsAction = {
+  householdsById: {},
+  type: REMOVE_HOUSEHOLDS,
+};
+
 // The reducer
 
 /** interface for clients state in redux store */
@@ -142,6 +148,11 @@ export default function reducer(
       return SeamlessImmutable({
         ...state,
         householdsById: { ...state.householdsById, ...action.householdsById },
+      });
+    case REMOVE_HOUSEHOLDS:
+      return SeamlessImmutable({
+        ...state,
+        householdsById: action.householdsById,
       });
     default:
       return state;

--- a/src/store/ducks/clients.ts
+++ b/src/store/ducks/clients.ts
@@ -188,3 +188,11 @@ export function getHouseholdsById(state: Partial<Store>): { [key: string]: House
 export function getHouseholdsArray(state: Partial<Store>): Household[] {
   return values(getHouseholdsById(state));
 }
+
+/** get a specific household by their id
+ * @param {Partial<Store>} state - the redux store
+ * @return {Household | null} a household obj if the id is found else null
+ */
+export function getHouseholdById(state: Partial<Store>, id: string): Household | null {
+  return get(getHouseholdsById(state), id) || null;
+}

--- a/src/store/ducks/clients.ts
+++ b/src/store/ducks/clients.ts
@@ -31,6 +31,9 @@ export interface Client {
   _rev: string;
 }
 
+/** Interface for household object as same as client */
+export type Household = Client;
+
 // actions
 
 /** CLIENTS_FETCHED action type */

--- a/src/store/ducks/clients.ts
+++ b/src/store/ducks/clients.ts
@@ -40,6 +40,8 @@ export type Household = Client;
 export const CLIENTS_FETCHED = 'opensrp/reducer/clients/CLIENTS_FETCHED';
 /** REMOVE_CLIENTS action type */
 export const REMOVE_CLIENTS = 'opensrp/reducer/clients/REMOVE_CLIENTS';
+/** HOUSEHOLDS_FETCHED action type */
+export const HOUSEHOLDS_FETCHED = 'opensrp/reducer/clients/HOUSEHOLDS_FETCHED';
 
 /** interface for authorize action */
 export interface FetchClientsAction extends AnyAction {
@@ -51,6 +53,12 @@ export interface FetchClientsAction extends AnyAction {
 interface RemoveClientsAction extends AnyAction {
   clientsById: {};
   type: typeof REMOVE_CLIENTS;
+}
+
+/** interface for fetchHouseholdsAction */
+interface FetchHouseholdsAction extends AnyAction{
+  householdsById: { [key: string]: Household };
+  type: typeof HOUSEHOLDS_FETCHED;
 }
 
 /** Create type for clients reducer actions */

--- a/src/store/ducks/clients.ts
+++ b/src/store/ducks/clients.ts
@@ -42,6 +42,8 @@ export const CLIENTS_FETCHED = 'opensrp/reducer/clients/CLIENTS_FETCHED';
 export const REMOVE_CLIENTS = 'opensrp/reducer/clients/REMOVE_CLIENTS';
 /** HOUSEHOLDS_FETCHED action type */
 export const HOUSEHOLDS_FETCHED = 'opensrp/reducer/clients/HOUSEHOLDS_FETCHED';
+/** REMOVE_HOUSEHOLDS action type */
+export const REMOVE_HOUSEHOLDS = 'opensrp/reducer/clients/REMOVE_HOUSEHOLDS';
 
 /** interface for authorize action */
 export interface FetchClientsAction extends AnyAction {
@@ -59,6 +61,12 @@ interface RemoveClientsAction extends AnyAction {
 interface FetchHouseholdsAction extends AnyAction {
   householdsById: { [key: string]: Household };
   type: typeof HOUSEHOLDS_FETCHED;
+}
+
+/** Interface for removeHouseholdsAction */
+interface RemoveHouseholdsAction extends AnyAction {
+  householdsById: {};
+  type: typeof REMOVE_HOUSEHOLDS;
 }
 
 /** Create type for clients reducer actions */

--- a/src/store/ducks/clients.ts
+++ b/src/store/ducks/clients.ts
@@ -56,7 +56,7 @@ interface RemoveClientsAction extends AnyAction {
 }
 
 /** interface for fetchHouseholdsAction */
-interface FetchHouseholdsAction extends AnyAction{
+interface FetchHouseholdsAction extends AnyAction {
   householdsById: { [key: string]: Household };
   type: typeof HOUSEHOLDS_FETCHED;
 }
@@ -77,6 +77,15 @@ export type ClientsActionTypes =
 export const fetchClients = (clientsList: Client[] = []): FetchClientsAction => ({
   clientsById: keyBy(clientsList, (client: Client) => client._id),
   type: CLIENTS_FETCHED,
+});
+
+/** Fetch households action creator
+ * @param {Household []} householdList - households array to add to store
+ * @return {FetchHouseholdsAction} - an action to add households to redux store
+ */
+export const fetchHouseholds = (householdsList: Household[] = []): FetchHouseholdsAction => ({
+  householdsById: keyBy(householdsList, (household: Household) => household._id),
+  type: HOUSEHOLDS_FETCHED,
 });
 
 // actions

--- a/src/store/ducks/tests/clients.test.ts
+++ b/src/store/ducks/tests/clients.test.ts
@@ -71,4 +71,18 @@ describe('reducers/clients', () => {
     numberOfClients = getClientsArray(store.getState()).length;
     expect(numberOfClients).toEqual(2);
   });
+
+  it('fetches households correctly', () => {
+    store.dispatch(fetchClients([fixtures.household1, fixtures.household2]));
+    expect(getHouseholdsById(store.getState())).toEqual({
+      '1bcb682a-0f31-4935-9114-c4d33d148617': fixtures.household1,
+      '2eeb682a-0f31-4935-9114-c4d33d148617': fixtures.household2,
+    });
+    expect(getHouseholdsArray(store.getState())).toEqual(
+      values([fixtures.household1, fixtures.household2])
+    );
+    expect(getHouseholdById(store.getState(), '1bcb682a-0f31-4935-9114-c4d33d148617')).toEqual(
+      fixtures.household1
+    );
+  });
 });

--- a/src/store/ducks/tests/clients.test.ts
+++ b/src/store/ducks/tests/clients.test.ts
@@ -4,6 +4,7 @@ import { FlushThunks } from 'redux-testkit';
 import store from '../../index';
 import reducer, {
   fetchClients,
+  fetchHouseholds,
   getClientById,
   getClients,
   getClientsArray,
@@ -73,7 +74,7 @@ describe('reducers/clients', () => {
   });
 
   it('fetches households correctly', () => {
-    store.dispatch(fetchClients([fixtures.household1, fixtures.household2]));
+    store.dispatch(fetchHouseholds([fixtures.household1, fixtures.household2]));
     expect(getHouseholdsById(store.getState())).toEqual({
       '1bcb682a-0f31-4935-9114-c4d33d148617': fixtures.household1,
       '2eeb682a-0f31-4935-9114-c4d33d148617': fixtures.household2,
@@ -84,5 +85,14 @@ describe('reducers/clients', () => {
     expect(getHouseholdById(store.getState(), '1bcb682a-0f31-4935-9114-c4d33d148617')).toEqual(
       fixtures.household1
     );
+  });
+
+  it('Adds new households to store instead of overwriting existing ones', () => {
+    let numberOfHouseholds = getHouseholdsArray(store.getState()).length;
+    expect(numberOfHouseholds).toEqual(2);
+
+    store.dispatch(fetchHouseholds([fixtures.household3]));
+    numberOfHouseholds = getHouseholdsArray(store.getState()).length;
+    expect(numberOfHouseholds).toEqual(3);
   });
 });

--- a/src/store/ducks/tests/clients.test.ts
+++ b/src/store/ducks/tests/clients.test.ts
@@ -26,6 +26,8 @@ describe('reducers/clients', () => {
   beforeEach(() => {
     flushThunks = FlushThunks.createMiddleware();
     jest.resetAllMocks();
+    store.dispatch(removeClientsAction);
+    store.dispatch(removeHouseholdsAction);
   });
 
   it('selectors work for empty initialState', () => {

--- a/src/store/ducks/tests/clients.test.ts
+++ b/src/store/ducks/tests/clients.test.ts
@@ -14,6 +14,7 @@ import reducer, {
   getHouseholdsById,
   reducerName,
   removeClientsAction,
+  removeHouseholdsAction,
 } from '../clients';
 import * as fixtures from '../tests/fixtures';
 
@@ -94,5 +95,15 @@ describe('reducers/clients', () => {
     store.dispatch(fetchHouseholds([fixtures.household3]));
     numberOfHouseholds = getHouseholdsArray(store.getState()).length;
     expect(numberOfHouseholds).toEqual(3);
+  });
+
+  it('removes Households', () => {
+    store.dispatch(fetchHouseholds(fixtures.households));
+    let numberOfHouseholds = getHouseholdsArray(store.getState()).length;
+    expect(numberOfHouseholds).toEqual(3);
+
+    store.dispatch(removeHouseholdsAction);
+    numberOfHouseholds = getHouseholdsArray(store.getState()).length;
+    expect(numberOfHouseholds).toEqual(0);
   });
 });

--- a/src/store/ducks/tests/clients.test.ts
+++ b/src/store/ducks/tests/clients.test.ts
@@ -6,8 +6,8 @@ import reducer, {
   fetchClients,
   fetchHouseholds,
   getClientById,
-  getClients,
   getClientsArray,
+  getClientsById,
   getClientsIdArray,
   getHouseholdById,
   getHouseholdsArray,
@@ -28,7 +28,7 @@ describe('reducers/clients', () => {
   });
 
   it('selectors work for empty initialState', () => {
-    expect(getClients(store.getState())).toEqual({});
+    expect(getClientsById(store.getState())).toEqual({});
     expect(getClientsArray(store.getState())).toEqual([]);
     expect(getClientsIdArray(store.getState())).toEqual([]);
     expect(getClientById(store.getState(), 'some-id')).toBeNull();
@@ -39,7 +39,7 @@ describe('reducers/clients', () => {
 
   it('fetches clients correctly', () => {
     store.dispatch(fetchClients([fixtures.client1, fixtures.client2]));
-    expect(getClients(store.getState())).toEqual({
+    expect(getClientsById(store.getState())).toEqual({
       '9b67a82d-dac7-40c0-85aa-e5976339a6b6': fixtures.client1,
       'a30116d5-0612-419e-9b93-00c87df4ffbb': fixtures.client2,
     });

--- a/src/store/ducks/tests/clients.test.ts
+++ b/src/store/ducks/tests/clients.test.ts
@@ -8,6 +8,9 @@ import reducer, {
   getClients,
   getClientsArray,
   getClientsIdArray,
+  getHouseholdById,
+  getHouseholdsArray,
+  getHouseholdsById,
   reducerName,
   removeClientsAction,
 } from '../clients';
@@ -28,6 +31,9 @@ describe('reducers/clients', () => {
     expect(getClientsArray(store.getState())).toEqual([]);
     expect(getClientsIdArray(store.getState())).toEqual([]);
     expect(getClientById(store.getState(), 'some-id')).toBeNull();
+    expect(getHouseholdsById(store.getState())).toEqual({});
+    expect(getHouseholdsArray(store.getState())).toEqual([]);
+    expect(getHouseholdById(store.getState(), 'test-id')).toBeNull();
   });
 
   it('fetches clients correctly', () => {

--- a/src/store/ducks/tests/clients.test.ts
+++ b/src/store/ducks/tests/clients.test.ts
@@ -89,6 +89,7 @@ describe('reducers/clients', () => {
   });
 
   it('Adds new households to store instead of overwriting existing ones', () => {
+    store.dispatch(fetchHouseholds([fixtures.household1, fixtures.household2]));
     let numberOfHouseholds = getHouseholdsArray(store.getState()).length;
     expect(numberOfHouseholds).toEqual(2);
 

--- a/src/store/ducks/tests/fixtures.ts
+++ b/src/store/ducks/tests/fixtures.ts
@@ -1,4 +1,4 @@
-import { Client } from '../../ducks/clients';
+import { Client, Household } from '../../ducks/clients';
 export const client1: Client = {
   type: 'Client',
   // tslint:disable-next-line: object-literal-sort-keys
@@ -258,5 +258,92 @@ export const client7: Client = {
   _id: '6dab682a-0f31-4935-9114-c4d33d148617',
   _rev: 'v1',
 };
+export const household1: Household = {
+  type: 'Client',
+  // tslint:disable-next-line: object-literal-sort-keys
+  dateCreated: 1657737728487,
+  serverVersion: 1557737728441,
+  clientApplicationVersion: 2,
+  clientDatabaseVersion: 2,
+  baseEntityId: '123fc98d-4cce-412a-8327-ca2315efedf3',
+  identifiers: {
+    opensrp_id: '22117124',
+  },
+  addresses: [],
+  attributes: {
+    residence: '6f7ca772-b368-4c3d-bd9c-00aa698203ca',
+  },
+  firstName: 'Nafiz',
+  middleName: '',
+  lastName: 'AHMED',
+  birthdate: 358560000000,
+  birthdateApprox: false,
+  deathdateApprox: false,
+  relationships: {
+    family_head: ['abc5181-c153-4bcc-85c3-0b7c3d9f2263'],
+    primary_caregiver: ['deff5181-c153-4bcc-85c3-0b7c3d9f2263'],
+  },
+  _id: '1bcb682a-0f31-4935-9114-c4d33d148617',
+  _rev: 'v1',
+};
+
+export const household2: Household = {
+  type: 'Client',
+  // tslint:disable-next-line: object-literal-sort-keys
+  dateCreated: 1757737728487,
+  serverVersion: 1557737728441,
+  clientApplicationVersion: 2,
+  clientDatabaseVersion: 2,
+  baseEntityId: '456fc98d-4cce-412a-8327-ca2315efedf3',
+  identifiers: {
+    opensrp_id: '33117124',
+  },
+  addresses: [],
+  attributes: {
+    residence: '6f7ca772-b368-4c3d-bd9c-00aa698203ca',
+  },
+  firstName: 'Proshanto',
+  middleName: '',
+  lastName: 'DADA',
+  birthdate: 358560000000,
+  birthdateApprox: false,
+  deathdateApprox: false,
+  relationships: {
+    family_head: ['ghif5181-c153-4bcc-85c3-0b7c3d9f2263'],
+    primary_caregiver: ['jklf5181-c153-4bcc-85c3-0b7c3d9f2263'],
+  },
+  _id: '2eeb682a-0f31-4935-9114-c4d33d148617',
+  _rev: 'v1',
+};
+
+export const household3: Household = {
+  type: 'Client',
+  // tslint:disable-next-line: object-literal-sort-keys
+  dateCreated: 1857737728487,
+  serverVersion: 1557737728441,
+  clientApplicationVersion: 2,
+  clientDatabaseVersion: 2,
+  baseEntityId: '789fc98d-4cce-412a-8327-ca2315efedf3',
+  identifiers: {
+    opensrp_id: '44117124',
+  },
+  addresses: [],
+  attributes: {
+    residence: '6f7ca772-b368-4c3d-bd9c-00aa698203ca',
+  },
+  firstName: 'Mahmud',
+  middleName: '',
+  lastName: 'BHAI',
+  birthdate: 358560000000,
+  birthdateApprox: false,
+  deathdateApprox: false,
+  relationships: {
+    family_head: ['mnof5181-c153-4bcc-85c3-0b7c3d9f2263'],
+    primary_caregiver: ['pqrf5181-c153-4bcc-85c3-0b7c3d9f2263'],
+  },
+  _id: '3ffb682a-0f31-4935-9114-c4d33d148617',
+  _rev: 'v1',
+};
 
 export const clients: Client[] = [client1, client2, client3, client4, client5, client6, client7];
+export const households: Household[] = [household1, household2, household3];


### PR DESCRIPTION
Reference to issue #34, this extends client dux to support households. It also creates household-specific actions and selectors.
In addition, this is same PR as #35 except with all signing commits. 