### PR TITLE
Turn all eslint errors into warnings

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,6 +16,7 @@ module.exports =  {
   rules:  {
     '@typescript-eslint/explicit-function-return-type': 'warn',
     '@typescript-eslint/no-inferrable-types': 'warn',
+    "prettier/prettier": "warn",
   },
   settings:  {
     react:  {


### PR DESCRIPTION
Why: It really irks me when linting issues are "scriggly-lined" as errors, especially given the fact that they are automaticaly fixed later.