### PR TITLE
Pass v2 opensrp url as prop

### DIFF
--- a/packages/populationCharacteristics/README.md
+++ b/packages/populationCharacteristics/README.md
@@ -30,6 +30,7 @@ const EditSetingsPage = () => {
         restBaseURL: <OpenSRP API base url>,
         secAuthEndpoint: <OpenSrp API security authenticate endpoint>,
         settingsEndpoint: <OpenSrp API settings endpoint>,
+        v2BaseUrl: <OpenSRP API v2 base url without rest at end>
     };
     return <ConnectedEditSetings {...editSetingsProps} />
 };
@@ -43,6 +44,7 @@ _locationsEndpoint_: OpenSrp API location tree endpoint
 _restBaseURL_: OpenSRP API base url
 _secAuthEndpoint_: OpenSrp API security authenticate endpoint,
 _settingsEndpoint_: OpenSrp API settings endpoint,
+_v2BaseUrl_: OpenSRP API v2 base url without rest at end
 
 ### Optional props
 

--- a/packages/populationCharacteristics/dist/components/EditSettings/index.js
+++ b/packages/populationCharacteristics/dist/components/EditSettings/index.js
@@ -62,7 +62,8 @@ var EditSetings = function EditSetings(props) {
       secAuthEndpoint = props.secAuthEndpoint,
       settingsEndpoint = props.settingsEndpoint,
       customAlert = props.customAlert,
-      debounceTime = props.debounceTime;
+      debounceTime = props.debounceTime,
+      v2BaseUrl = props.v2BaseUrl;
   var pageTitle = labels.pageTitle,
       placeholder = labels.placeholder,
       descriptionLabel = labels.descriptionLabel,
@@ -95,7 +96,7 @@ var EditSetings = function EditSetings(props) {
     var params = {
       locationId: currentLocId
     };
-    var clientService = new _serverService.OpenSRPService(restBaseURL, settingsEndpoint, getPayload);
+    var clientService = new _serverService.OpenSRPService(v2BaseUrl, settingsEndpoint, getPayload);
     return clientService.list(params);
   };
 

--- a/packages/populationCharacteristics/dist/types/components/EditSettings/index.d.ts
+++ b/packages/populationCharacteristics/dist/types/components/EditSettings/index.d.ts
@@ -25,5 +25,5 @@ declare const EditSetings: {
 declare const ConnectedEditSetings: import("react-redux").ConnectedComponent<{
     (props: FormConfigProps & EditSettingsDefaultProps): JSX.Element;
     defaultProps: EditSettingsDefaultProps;
-}, Pick<FormConfigProps & EditSettingsDefaultProps, "debounceTime" | "labels" | "baseURL" | "customAlert" | "getPayload" | "LoadingComponent" | "locationsEndpoint" | "restBaseURL" | "secAuthEndpoint" | "settingsEndpoint">>;
+}, Pick<FormConfigProps & EditSettingsDefaultProps, "debounceTime" | "labels" | "baseURL" | "customAlert" | "getPayload" | "LoadingComponent" | "locationsEndpoint" | "restBaseURL" | "secAuthEndpoint" | "settingsEndpoint" | "v2BaseUrl">>;
 export { EditSetings, ConnectedEditSetings };

--- a/packages/populationCharacteristics/dist/types/helpers/types.d.ts
+++ b/packages/populationCharacteristics/dist/types/helpers/types.d.ts
@@ -11,6 +11,7 @@ export interface FormConfigProps {
     restBaseURL: string;
     secAuthEndpoint: string;
     settingsEndpoint: string;
+    v2BaseUrl: string;
 }
 /** interface for all displayed strings */
 export interface EditSettingLabels {

--- a/packages/populationCharacteristics/src/components/EditSettings/index.tsx
+++ b/packages/populationCharacteristics/src/components/EditSettings/index.tsx
@@ -55,6 +55,7 @@ const EditSetings = (props: FormConfigProps & EditSettingsDefaultProps) => {
         settingsEndpoint,
         customAlert,
         debounceTime,
+        v2BaseUrl,
     } = props;
 
     const {
@@ -82,7 +83,7 @@ const EditSetings = (props: FormConfigProps & EditSettingsDefaultProps) => {
     const getLocationSettings = (currentLocId: string) => {
         setLoading(true);
         const params = { locationId: currentLocId };
-        const clientService = new OpenSRPService(restBaseURL, settingsEndpoint, getPayload);
+        const clientService = new OpenSRPService(v2BaseUrl, settingsEndpoint, getPayload);
         return clientService.list(params);
     };
 

--- a/packages/populationCharacteristics/src/components/EditSettings/tests/index.test.tsx
+++ b/packages/populationCharacteristics/src/components/EditSettings/tests/index.test.tsx
@@ -38,6 +38,7 @@ const props = {
     restBaseURL,
     secAuthEndpoint: 'security/authenticate',
     settingsEndpoint: 'settings',
+    v2BaseUrl: 'https://test-example.com/opensrp/rest/v2/',
 };
 
 describe('components/Editsettings', () => {

--- a/packages/populationCharacteristics/src/helpers/types.ts
+++ b/packages/populationCharacteristics/src/helpers/types.ts
@@ -11,6 +11,7 @@ export interface FormConfigProps {
     restBaseURL: string;
     secAuthEndpoint: string;
     settingsEndpoint: string;
+    v2BaseUrl: string;
 }
 
 /** interface for all displayed strings */


### PR DESCRIPTION
Exposes a prop `v2BaseUrl` for passing OpenSrp v2 server url.