### PR TITLE
Additional params for fetching characteristics server settings

### DIFF
--- a/packages/populationCharacteristics/dist/components/EditSettings/index.js
+++ b/packages/populationCharacteristics/dist/components/EditSettings/index.js
@@ -39,6 +39,8 @@ var _SearchForm = require("../SearchForm");
 
 var _utils = require("../../helpers/utils");
 
+var _constants = require("../../constants");
+
 function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
 
 function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(Object(source), true).forEach(function (key) { (0, _defineProperty2["default"])(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
@@ -94,7 +96,10 @@ var EditSetings = function EditSetings(props) {
   var getLocationSettings = function getLocationSettings(currentLocId) {
     setLoading(true);
     var params = {
-      locationId: currentLocId
+      identifier: _constants.POP_CHARACTERISTICS_PARAM,
+      locationId: currentLocId,
+      resolve: true,
+      serverVersion: 0
     };
     var clientService = new _serverService.OpenSRPService(v2BaseUrl, settingsEndpoint, getPayload);
     return clientService.list(params);

--- a/packages/populationCharacteristics/dist/constants.js
+++ b/packages/populationCharacteristics/dist/constants.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.NO_DATA_FOUND = exports.INHERIT_SETTING_LABEL = exports.SET_TO_NO_LABEL = exports.SET_TO_YES_LABEL = exports.NAME_LABEL = exports.INHERITED_FROM_LABEL = exports.SETTINGS_LABEL = exports.DESCRIPTION_LABEL = exports.EDIT_LABEL = exports.PAGE_TITLE_LABEL = exports.SEARCH_SETTINGS_LABEL = exports.SEARCH_LABEL = void 0;
+exports.POP_CHARACTERISTICS_PARAM = exports.NO_DATA_FOUND = exports.INHERIT_SETTING_LABEL = exports.SET_TO_NO_LABEL = exports.SET_TO_YES_LABEL = exports.NAME_LABEL = exports.INHERITED_FROM_LABEL = exports.SETTINGS_LABEL = exports.DESCRIPTION_LABEL = exports.EDIT_LABEL = exports.PAGE_TITLE_LABEL = exports.SEARCH_SETTINGS_LABEL = exports.SEARCH_LABEL = void 0;
 var SEARCH_LABEL = 'Search';
 exports.SEARCH_LABEL = SEARCH_LABEL;
 var SEARCH_SETTINGS_LABEL = 'Search Settings';
@@ -28,3 +28,5 @@ var INHERIT_SETTING_LABEL = 'Inherit setting';
 exports.INHERIT_SETTING_LABEL = INHERIT_SETTING_LABEL;
 var NO_DATA_FOUND = 'No data found';
 exports.NO_DATA_FOUND = NO_DATA_FOUND;
+var POP_CHARACTERISTICS_PARAM = 'population_characteristics';
+exports.POP_CHARACTERISTICS_PARAM = POP_CHARACTERISTICS_PARAM;

--- a/packages/populationCharacteristics/dist/styles/index.css
+++ b/packages/populationCharacteristics/dist/styles/index.css
@@ -4,7 +4,6 @@
     vertical-align: top;
     border-top: 1px solid #dee2e6;
     max-width: 340px;
-    font-size: 14px;
 }
 
 .title {

--- a/packages/populationCharacteristics/dist/types/constants.d.ts
+++ b/packages/populationCharacteristics/dist/types/constants.d.ts
@@ -10,3 +10,4 @@ export declare const SET_TO_YES_LABEL = "Set to 'Yes'";
 export declare const SET_TO_NO_LABEL = "Set to 'No'";
 export declare const INHERIT_SETTING_LABEL = "Inherit setting";
 export declare const NO_DATA_FOUND = "No data found";
+export declare const POP_CHARACTERISTICS_PARAM = "population_characteristics";

--- a/packages/populationCharacteristics/src/components/EditSettings/index.tsx
+++ b/packages/populationCharacteristics/src/components/EditSettings/index.tsx
@@ -17,6 +17,7 @@ import { LocationMenu } from '../LocationsMenu';
 import { FormConfigProps, EditSettingLabels } from '../../helpers/types';
 import { SearchForm } from '../SearchForm';
 import { preparePutData, labels, EditSettingsButton } from '../../helpers/utils';
+import { POP_CHARACTERISTICS_PARAM } from '../../constants';
 
 /** dafault edit settings interface */
 interface EditSettingsDefaultProps {
@@ -82,7 +83,12 @@ const EditSetings = (props: FormConfigProps & EditSettingsDefaultProps) => {
      */
     const getLocationSettings = (currentLocId: string) => {
         setLoading(true);
-        const params = { locationId: currentLocId };
+        const params = {
+            identifier: POP_CHARACTERISTICS_PARAM,
+            locationId: currentLocId,
+            resolve: true,
+            serverVersion: 0,
+        };
         const clientService = new OpenSRPService(v2BaseUrl, settingsEndpoint, getPayload);
         return clientService.list(params);
     };

--- a/packages/populationCharacteristics/src/components/EditSettings/tests/index.test.tsx
+++ b/packages/populationCharacteristics/src/components/EditSettings/tests/index.test.tsx
@@ -74,6 +74,16 @@ describe('components/Editsettings', () => {
             wrapper.update();
         });
 
+        expect(mockList).toHaveBeenCalledTimes(2);
+        expect(mockList.mock.calls[1]).toEqual([
+            {
+                identifier: 'population_characteristics',
+                locationId: '75af7700-a6f2-448c-a17d-816261a7749a',
+                resolve: true,
+                serverVersion: 0,
+            },
+        ]);
+
         store.dispatch(fetchLocs(locHierarchy));
         store.dispatch(fetchLocSettings(allSettings, '75af7700-a6f2-448c-a17d-816261a7749a'));
         wrapper.update();

--- a/packages/populationCharacteristics/src/constants.ts
+++ b/packages/populationCharacteristics/src/constants.ts
@@ -10,3 +10,4 @@ export const SET_TO_YES_LABEL = `Set to 'Yes'`;
 export const SET_TO_NO_LABEL = `Set to 'No'`;
 export const INHERIT_SETTING_LABEL = 'Inherit setting';
 export const NO_DATA_FOUND = 'No data found';
+export const POP_CHARACTERISTICS_PARAM = 'population_characteristics';

--- a/packages/populationCharacteristics/src/styles/index.css
+++ b/packages/populationCharacteristics/src/styles/index.css
@@ -4,7 +4,6 @@
     vertical-align: top;
     border-top: 1px solid #dee2e6;
     max-width: 340px;
-    font-size: 14px;
 }
 
 .title {


### PR DESCRIPTION
Closes #273 
Add identifier, serverVersion and resolve querry params to settings get url. 
This params ensures we only get population characteristics server settings and if a lower location doesn't have settings, settings of the higher location are returned.